### PR TITLE
Protections against memory exhaustion on large documents

### DIFF
--- a/config.json
+++ b/config.json
@@ -33,7 +33,8 @@
         ".json",
         "zendesk",
         "clickserve",
-        ".png"
+        ".png",
+        ".iso"
     ],
     "user_agents": [
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.7 (KHTML, like Gecko) Version/9.1.2 Safari/601.7.7",

--- a/noisy.py
+++ b/noisy.py
@@ -238,6 +238,9 @@ class Crawler(object):
 
                 except requests.exceptions.RequestException:
                     logging.warn("Error connecting to root url: {}".format(url))
+                
+                except MemoryError:
+                    logging.warn("Error: content at url: {} is exhausting the memory".format(url))
 
                 except self.CrawlerTimedOut:
                     logging.info("Timeout has exceeded, exiting")


### PR DESCRIPTION
Noisy encountered an exception when crawling http://mirror.archlinux.cl/iso/2018.08.01/archlinux-2018.08.01-x86_64.iso

This pull request proposes to catch MemoryError, and try to avoid processing iso files.

